### PR TITLE
Unhardcode Scala 2.10.x from ScalaTest dependency ...

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ version := "0.1"
 scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-contrib" % "2.3.4",
-  "com.typesafe.akka" %% "akka-testkit" % "2.3.4",
-  "org.scalatest" % "scalatest_2.10" % "2.1.6" % "test",
+  "com.typesafe.akka" %% "akka-contrib" % "2.3.6",
+  "com.typesafe.akka" %% "akka-testkit" % "2.3.6",
+  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "commons-io" % "commons-io" % "2.4" % "test")


### PR DESCRIPTION
and enable project being built with Scala 2.11.x

Test pass with Scala 2.10.4 and Scala 2.11.2.
